### PR TITLE
fix: Windows wheel creation

### DIFF
--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -32,6 +32,7 @@
  * Date: August 2018
  */
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdint>


### PR DESCRIPTION
Fixes `error C2039: 'min': is not a member of 'std'` using the VS Build Tools on Windows.