### PR TITLE
perf: limit union-find allocation by maximum representation size

### DIFF
--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -255,6 +255,7 @@ OUT* connected_components3d_26(
 	const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -449,6 +450,7 @@ OUT* connected_components3d_18(
   const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -594,6 +596,7 @@ OUT* connected_components3d_6(
   const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 

--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -60,7 +60,7 @@ public:
   size_t length;
 
   DisjointSet () {
-    length = 65536;
+    length = 65536; // 2^16, some "reasonable" starting size
     ids = new T[length]();
   }
 
@@ -255,7 +255,7 @@ OUT* connected_components3d_26(
 	const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
+  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -450,7 +450,7 @@ OUT* connected_components3d_18(
   const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
+  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -596,7 +596,7 @@ OUT* connected_components3d_6(
   const int64_t voxels = sxy * sz;
 
   max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(pow(2, sizeof(OUT) * 8)));
+  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 

--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -248,15 +248,15 @@ template <typename T, typename OUT = uint32_t>
 OUT* connected_components3d_26(
     T* in_labels, 
     const int64_t sx, const int64_t sy, const int64_t sz,
-    int64_t max_labels, OUT *out_labels = NULL
+    size_t max_labels, OUT *out_labels = NULL
   ) {
 
 	const int64_t sxy = sx * sy;
 	const int64_t voxels = sxy * sz;
 
-  max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
-
+  max_labels = std::max(std::min(max_labels, static_cast<size_t>(voxels)), static_cast<size_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<size_t>(std::numeric_limits<OUT>::max()));  
+  
   DisjointSet<uint32_t> equivalences(max_labels);
 
   if (out_labels == NULL) {
@@ -443,14 +443,14 @@ template <typename T, typename OUT = uint32_t>
 OUT* connected_components3d_18(
     T* in_labels, 
     const int64_t sx, const int64_t sy, const int64_t sz,
-    int64_t max_labels, OUT *out_labels = NULL
+    size_t max_labels, OUT *out_labels = NULL
   ) {
 
   const int64_t sxy = sx * sy;
   const int64_t voxels = sxy * sz;
 
-  max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
+  max_labels = std::max(std::min(max_labels, static_cast<size_t>(voxels)), static_cast<size_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<size_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -589,14 +589,14 @@ template <typename T, typename OUT = uint32_t>
 OUT* connected_components3d_6(
     T* in_labels, 
     const int64_t sx, const int64_t sy, const int64_t sz,
-    int64_t max_labels, OUT *out_labels = NULL
+    size_t max_labels, OUT *out_labels = NULL
   ) {
 
   const int64_t sxy = sx * sy;
   const int64_t voxels = sxy * sz;
 
-  max_labels = std::max(std::min(max_labels, voxels), static_cast<int64_t>(1L)); // can't allocate 0 arrays
-  max_labels = std::min(max_labels, static_cast<int64_t>(std::numeric_limits<OUT>::max()));
+  max_labels = std::max(std::min(max_labels, static_cast<size_t>(voxels)), static_cast<size_t>(1L)); // can't allocate 0 arrays
+  max_labels = std::min(max_labels, static_cast<size_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<uint32_t> equivalences(max_labels);
 
@@ -677,7 +677,7 @@ template <typename T, typename OUT = uint32_t>
 OUT* connected_components3d(
     T* in_labels, 
     const int64_t sx, const int64_t sy, const int64_t sz,
-    int64_t max_labels, const int64_t connectivity,
+    size_t max_labels, const int64_t connectivity,
     OUT *out_labels = NULL
   ) {
 


### PR DESCRIPTION
It's pointless to allocate more than 2^16 for uint16 arrays as
the individual slots can't refer to anything larger than that.

The union find array doesn't get touched by naked labels (only
the monotonically incrementing next_label variable) so there's no
chance that there might be a valid index into it that's greater than
its representation value.