### PR TITLE
perf(relabel): collapse union-find into simple array remap

### DIFF
--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -223,7 +223,7 @@ OUT* relabel(
   OUT* renumber = new OUT[num_labels + 1]();
   OUT next_label = 1;
 
-  for (int64_t i = 1; i < num_labels; i++) {
+  for (int64_t i = 1; i <= num_labels; i++) {
     label = equivalences.root(i);
     if (renumber[label] == 0) {
       renumber[label] = next_label;
@@ -237,21 +237,7 @@ OUT* relabel(
 
   // Raster Scan 2: Write final labels based on equivalences
   for (int64_t loc = 0; loc < voxels; loc++) {
-    if (!out_labels[loc]) {
-      continue;
-    }
-   
-    // label = equivalences.root(out_labels[loc]);
     out_labels[loc] = renumber[out_labels[loc]];
-
-    // if (renumber[label]) {
-    //   out_labels[loc] = renumber[label];
-    // }
-    // else {
-    //   renumber[label] = next_label;
-    //   out_labels[loc] = next_label;
-    //   next_label++;
-    // }
   }
 
   delete[] renumber;

--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -223,22 +223,35 @@ OUT* relabel(
   OUT* renumber = new OUT[num_labels + 1]();
   OUT next_label = 1;
 
+  for (int64_t i = 1; i < num_labels; i++) {
+    label = equivalences.root(i);
+    if (renumber[label] == 0) {
+      renumber[label] = next_label;
+      renumber[i] = next_label;
+      next_label++;
+    }
+    else {
+      renumber[i] = renumber[label];
+    }
+  }
+
   // Raster Scan 2: Write final labels based on equivalences
   for (int64_t loc = 0; loc < voxels; loc++) {
     if (!out_labels[loc]) {
       continue;
     }
    
-    label = equivalences.root(out_labels[loc]);
+    // label = equivalences.root(out_labels[loc]);
+    out_labels[loc] = renumber[out_labels[loc]];
 
-    if (renumber[label]) {
-      out_labels[loc] = renumber[label];
-    }
-    else {
-      renumber[label] = next_label;
-      out_labels[loc] = next_label;
-      next_label++;
-    }
+    // if (renumber[label]) {
+    //   out_labels[loc] = renumber[label];
+    // }
+    // else {
+    //   renumber[label] = next_label;
+    //   out_labels[loc] = next_label;
+    //   next_label++;
+    // }
   }
 
   delete[] renumber;


### PR DESCRIPTION
### 8 connected
On YACCLAB fingerprints, ~185 MPx/sec -> ~280 MPx/sec (1.5x)!
On YACCLAB medical, improvement from ~240 MPx/sec -> ~280 MPx/sec (1.17x)

### 26 connected
On pinky40subvol,  90.83 MVx/sec -> 118.28 MVx/sec (1.30x)
On random array (0 to 10,000), 52.09 MVx/sec -> 50.70 MVx/sec (0.97x)
On test_v0 102.57 -> 128.59 MVx/sec (1.25x)