### PR TITLE
perf: improve speed of 26, 4, and 8 connected continuous labeling

### DIFF
--- a/cc3d_continuous.hpp
+++ b/cc3d_continuous.hpp
@@ -302,16 +302,20 @@ OUT* connected_components2d_8(
       }
 
       bool any = false;
-      if (x > 0 && y > 0 && in_labels[loc + A] && MATCH(cur, in_labels[loc + A])) {
-        out_labels[loc] = out_labels[loc + A];
+      if (y > 0 && cur == in_labels[loc + B]) {
+        out_labels[loc] = out_labels[loc + B];
+        continue;
+      }
+      else if (y > 0 && in_labels[loc + B] && MATCH(cur, in_labels[loc + B])) {
+        out_labels[loc] = out_labels[loc + B];
         any = true;
       }
-      if (y > 0 && in_labels[loc + B] && MATCH(cur, in_labels[loc + B])) {
+      if (x > 0 && y > 0 && in_labels[loc + A] && MATCH(cur, in_labels[loc + A])) {
         if (any) {
-          equivalences.unify(out_labels[loc], out_labels[loc + B]);
+          equivalences.unify(out_labels[loc], out_labels[loc + A]);
         }
         else {
-          out_labels[loc] = out_labels[loc + B];
+          out_labels[loc] = out_labels[loc + A];
         }
         any = true;
       }
@@ -333,7 +337,6 @@ OUT* connected_components2d_8(
         }
         any = true;
       }
-
 
       if (!any) {
         next_label++;

--- a/cc3d_continuous.hpp
+++ b/cc3d_continuous.hpp
@@ -127,6 +127,15 @@ OUT* connected_components3d_continuous(
           continue;
         }
 
+        // The location below the target voxel is exceptionally valuable
+        // It alone is also connected to all of the other voxels in the
+        // mask. If it matches, we can assume all voxels have already been
+        // processed identically.
+        if (z > 0 && connectivity == 26 && cur == in_labels[loc - sxy]) {
+          out_labels[loc] = out_labels[loc - sxy];
+          continue;
+        }
+
         compute_neighborhood(neighborhood, x, y, z, sx, sy, sz, connectivity);
         bool any = false;
 

--- a/cc3d_continuous.hpp
+++ b/cc3d_continuous.hpp
@@ -198,6 +198,7 @@ OUT* connected_components2d_4(
   const int64_t A = 0;
   const int64_t B = -1;
   const int64_t C = -sx;
+  const int64_t D = -1 - sx;
 
   int64_t loc = 0;
   int64_t row = 0;
@@ -221,8 +222,10 @@ OUT* connected_components2d_4(
 
       if (x > 0 && in_labels[loc + B] && MATCH(cur, in_labels[loc + B])) {
         out_labels[loc + A] = out_labels[loc + B];
-        if (y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {
-          equivalences.unify(out_labels[loc + A], out_labels[loc + C]);
+        if (y > 0 && cur != in_labels[loc + D]) {
+          if (y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {
+            equivalences.unify(out_labels[loc + A], out_labels[loc + C]);
+          }
         }
       }
       else if (y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {


### PR DESCRIPTION
Take advantage of structure in the continuous case. 
- If two values match within a neighborhood, their mutual neighbors will be affected identically.
- If the "catbird" neighbor and the current voxel's combined "range" encompasses the range of the dataset, then the local area can be treated as a binary problem.
    - If this is true globally, then the entire problem can be treated with a binary decision tree (the one that has the most literature written about it). However, I don't think I have the time to do that right now.