### PR TITLE
perf: faster continuous CCL for signed types

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,6 +8,10 @@ Except where noted, we compared the time and memory performance of both librarie
 
 The volume is derived from an early experimental segmentation of pinky40, a predecessor to the now public pinky100_v185 automatic segmentation of mouse brain now available at https://microns-explorer.org/phase1. You need to gzip decompress to recover the uncompressed file: `gunzip connectomics.npy.gz`
 
+## Image Data
+
+`Misc_pollen.npy` is the microscopy image from https://en.wikipedia.org/wiki/Scanning_electron_microscope#/media/File:Misc_pollen.jpg which is a public domain photo taken by the Dartmouth College Electron Microscope Facility in 2004.
+
 # Multi-Label Comparison
 
 <p style="font-style: italics;" align="center">

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -82,10 +82,32 @@ def test_multilabel_speed(labels, connectivity=26):
     prettyprint(dt, voxels)
   summary(times, voxels)
 
-labels = np.load("connectomics.npy")
+def test_continuous_speed(labels, connectivity=8):
+  voxels = labels.size
+  upper = np.max(labels)
+
+  def _run(delta):
+    print(f"Delta {delta}...")
+    times = []
+    for i in range(10):
+      s = time.time()
+      cc3d.connected_components(labels, connectivity=connectivity, delta=delta)
+      e = time.time()
+      dt = e-s
+      times.append(dt)
+    summary(times, voxels)
+
+  for delta in range(0,int(upper),int(upper/10)):
+    _run(delta)
+  _run(upper)
+
+
 # cc3d_mutlilabel_extraction(labels)
 # ndimage_mutlilabel_extraction(labels)
+# test_multilabel_speed(labels)
 
-test_multilabel_speed(labels)
+labels = np.load("Misc_pollen.npy").astype(np.float32)
+test_continuous_speed(labels)
+
 
 

--- a/cc3d_continuous.hpp
+++ b/cc3d_continuous.hpp
@@ -74,7 +74,20 @@ inline void compute_neighborhood(
 
 namespace cc3d {
 
-#define MATCH(cur, val) (std::max((cur), (val)) - std::min((cur), (val)) <= delta)
+// abs doesn't work with unsigned ints
+// #define MATCH(cur, val) (std::max((cur), (val)) - std::min((cur), (val)) <= delta)
+
+
+template <typename T>
+typename std::enable_if<std::is_unsigned<T>::value, bool>::type 
+match(const T cur, const T val, const T delta) {
+  return std::max((cur), (val)) - std::min((cur), (val)) <= delta;
+}
+template <typename T>
+typename std::enable_if<std::is_signed<T>::value, bool>::type 
+match(const T cur, const T val, const T delta) {
+  return std::abs(cur - val) <= delta;
+}
 
 template <typename T, typename OUT = uint32_t>
 OUT* connected_components3d_continuous(
@@ -146,7 +159,7 @@ OUT* connected_components3d_continuous(
             continue;
           }
 
-          if (MATCH(cur, in_labels[loc + neighbor])) {
+          if (match<T>(cur, in_labels[loc + neighbor], delta)) {
             if (any) {
               equivalences.unify(out_labels[loc], out_labels[loc + neighbor]);
             }
@@ -229,15 +242,15 @@ OUT* connected_components2d_4(
         continue;
       }
 
-      if (x > 0 && in_labels[loc + B] && MATCH(cur, in_labels[loc + B])) {
+      if (x > 0 && in_labels[loc + B] && match(cur, in_labels[loc + B], delta)) {
         out_labels[loc + A] = out_labels[loc + B];
         if (y > 0 && cur != in_labels[loc + D]) {
-          if (y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {
+          if (y > 0 && in_labels[loc + C] && match(cur, in_labels[loc + C], delta)) {
             equivalences.unify(out_labels[loc + A], out_labels[loc + C]);
           }
         }
       }
-      else if (y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {
+      else if (y > 0 && in_labels[loc + C] && match(cur, in_labels[loc + C], delta)) {
         out_labels[loc + A] = out_labels[loc + C];
       }
       else {
@@ -335,11 +348,11 @@ OUT* connected_components2d_8(
         continue;        
       }
 
-      if (y > 0 && in_labels[loc + B] && MATCH(cur, in_labels[loc + B])) {
+      if (y > 0 && in_labels[loc + B] && match(cur, in_labels[loc + B], delta)) {
         out_labels[loc] = out_labels[loc + B];
         any = true;
       }
-      if (x > 0 && y > 0 && in_labels[loc + A] && MATCH(cur, in_labels[loc + A])) {
+      if (x > 0 && y > 0 && in_labels[loc + A] && match(cur, in_labels[loc + A], delta)) {
         if (any) {
           equivalences.unify(out_labels[loc], out_labels[loc + A]);
         }
@@ -348,7 +361,7 @@ OUT* connected_components2d_8(
         }
         any = true;
       }
-      if (x < sx - 1 && y > 0 && in_labels[loc + C] && MATCH(cur, in_labels[loc + C])) {
+      if (x < sx - 1 && y > 0 && in_labels[loc + C] && match(cur, in_labels[loc + C], delta)) {
         if (any) {
           equivalences.unify(out_labels[loc], out_labels[loc + C]);
         }
@@ -357,7 +370,7 @@ OUT* connected_components2d_8(
         }
         any = true;
       }
-      if (x > 0 && in_labels[loc + D] && MATCH(cur, in_labels[loc + D])) {
+      if (x > 0 && in_labels[loc + D] && match(cur, in_labels[loc + D], delta)) {
         if (any) {
           equivalences.unify(out_labels[loc], out_labels[loc + D]);
         }
@@ -442,8 +455,6 @@ OUT* connected_components3d(
     NULL, N
   );
 }
-
-#undef MATCH
 
 };
 

--- a/cc3d_continuous.hpp
+++ b/cc3d_continuous.hpp
@@ -74,15 +74,19 @@ inline void compute_neighborhood(
 
 namespace cc3d {
 
-// abs doesn't work with unsigned ints
-// #define MATCH(cur, val) (std::max((cur), (val)) - std::min((cur), (val)) <= delta)
-
-
+// For unsigned ints, use this more expensive calculation
+// to avoid underflows. The typename/enable if buisness below
+// replaces the return type and results in "bool" if T is signed
+// or unsigned as the case may be. Then only the proper function is
+// generated and available for compilation for a given type.
 template <typename T>
 typename std::enable_if<std::is_unsigned<T>::value, bool>::type 
 match(const T cur, const T val, const T delta) {
   return std::max((cur), (val)) - std::min((cur), (val)) <= delta;
 }
+
+// For signed types (ints, floats) we can use the absolute value
+// which is significantly fewer assembly instructions.
 template <typename T>
 typename std::enable_if<std::is_signed<T>::value, bool>::type 
 match(const T cur, const T val, const T delta) {


### PR DESCRIPTION
Test run on the pollen image casted to float32. Times are given in MVx/sec. Note that delta=0 triggers the multi-label CCL algorithm.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/2517065/143942517-c6754326-8d5a-4e8b-9b67-89070389d39c.png">
