### PR TITLE
feat: voxel connectivity graph to labeled image

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -1341,7 +1341,10 @@ def test_color_connectivity_graph_8_uint32():
   assert np.all(cc_labels == ans)
 
 def test_color_connectivity_graph_6():
-  vcg = np.zeros([2,1])
+
+  with pytest.raises(ValueError):
+    vcg = np.zeros([2,2,2], dtype=np.uint8, order="F")
+    cc3d.color_connectivity_graph(vcg, connectivity=6)
 
 
   vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")

--- a/automated_test.py
+++ b/automated_test.py
@@ -1296,12 +1296,14 @@ def test_color_connectivity_graph_4(dtype, connectivity):
   ans = np.array([[1, 3],[2, 4]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
 
-  vcg[:] = 0b1111
-  vcg[0,0] = 0b1110
-  vcg[1,0] = 0b1101
-  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
-  ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
-  assert np.all(cc_labels == ans)
+
+  # This is aphysical
+  # vcg[:] = 0b1111
+  # vcg[0,0] = 0b1110
+  # vcg[1,0] = 0b1101
+  # cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  # ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
+  # assert np.all(cc_labels == ans)
 
   vcg[:] = 0b1111
   vcg[0,0] = 0b1110

--- a/automated_test.py
+++ b/automated_test.py
@@ -1339,3 +1339,34 @@ def test_color_connectivity_graph_8_uint32():
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=8)
   ans = np.array([[1, 2],[2, 1]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
+
+def test_color_connectivity_graph_6():
+  vcg = np.zeros([2,1])
+
+
+  vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")
+  vcg[:,:,:] = 0b11111111111111111111111111
+
+  vcg[:,:,4] = vcg[:,:,4] & 0b101111
+  vcg[:,:,5] = vcg[:,:,5] & 0b011111
+
+  vcg[:,4,:] = vcg[:,4,:] & 0b111011
+  vcg[:,5,:] = vcg[:,5,:] & 0b110111
+
+  vcg[4,:,:] = vcg[4,:,:] & 0b111110
+  vcg[5,:,:] = vcg[5,:,:] & 0b111101
+
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=6)
+
+  out = np.zeros(vcg.shape, dtype=np.uint32, order="F")
+  out[:5,:5,:5] = 1
+  out[5:,:5,:5] = 2
+  out[:5,5:,:5] = 3
+  out[5:,5:,:5] = 4
+  out[:5,:5,5:] = 5
+  out[5:,:5,5:] = 6
+  out[:5,5:,5:] = 7
+  out[5:,5:,5:] = 8
+
+  assert np.all(out == cc_labels)
+

--- a/automated_test.py
+++ b/automated_test.py
@@ -1260,3 +1260,25 @@ def test_periodic_boundary_6():
   assert N == 2
 
 
+def test_color_connectivity_graph_6():
+  vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")
+  vcg[:,:,:] = 0b11111111111111111111111111
+
+  vcg[:,:,5] = vcg[:,:,5] & 0b1111
+  vcg[:,5,:] = vcg[:,5,:] & 0b110011
+  vcg[5,:,:] = vcg[5,:,:] & 0b111100
+
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=6)
+
+  out = np.zeros(vcg.shape, dtype=np.uint32, order="F")
+  out[:5,:5,:5] = 1
+  out[5:,:5,:5] = 2
+  out[:5,5:,:5] = 3
+  out[5:,5:,:5] = 4
+  out[:5,:5,5:] = 5
+  out[5:,:5,5:] = 6
+  out[:5,5:,5:] = 7
+  out[5:,5:,5:] = 8
+  
+  assert np.all(out == cc_labels)
+

--- a/automated_test.py
+++ b/automated_test.py
@@ -1320,3 +1320,13 @@ def test_color_connectivity_graph_4(dtype, connectivity):
   ans = np.array([[1, 3],[2, 3]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
 
+def test_color_connectivity_graph_8_uint8():
+  vcg = np.zeros([2,2], dtype=np.uint8)
+  vcg[0,0] = 0b10000
+  vcg[1,1] = 0b10000000
+  vcg[1,0] = 0b100000
+  vcg[0,1] = 0b1000000
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=8)
+  ans = np.array([[1, 2],[2, 1]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+

--- a/automated_test.py
+++ b/automated_test.py
@@ -1260,25 +1260,63 @@ def test_periodic_boundary_6():
   assert N == 2
 
 
-def test_color_connectivity_graph_6():
-  vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")
-  vcg[:,:,:] = 0b11111111111111111111111111
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint32])
+@pytest.mark.parametrize("connectivity", [4,8])
+def test_color_connectivity_graph_4(dtype, connectivity):
+  vcg = np.array([[]], dtype=dtype)
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  assert cc_labels.size == 0
 
-  vcg[:,:,5] = vcg[:,:,5] & 0b1111
-  vcg[:,5,:] = vcg[:,5,:] & 0b110011
-  vcg[5,:,:] = vcg[5,:,:] & 0b111100
+  vcg = np.zeros([2,1], dtype=dtype)
+  vcg[:] = 0x0f
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([1,1], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
 
-  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=6)
+  vcg = np.zeros([2,1], dtype=dtype)
+  vcg[:] = 0b1100
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1],[2]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+  print("THIS TEST")
+  vcg = np.zeros([1,2], dtype=dtype)
+  vcg[:] = 0b1100
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([1,1], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+  print("REACHED HERE")
+  vcg[:] = 0b0011
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  print(cc_labels)
+  ans = np.array([1,2], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+  print("REACHED HERE2")
+  vcg = np.zeros([2,2], dtype=dtype)
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1, 3],[2, 4]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+  print("REACHED HERE3")
+  vcg[:] = 0b1111
+  vcg[0,0] = 0b1110
+  vcg[1,0] = 0b1101
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
+  print("REACHED HERE4")
+  vcg[:] = 0b1111
+  vcg[0,0] = 0b1110
+  vcg[1,0] = 0b1101
+  vcg[1,1] = 0b0111
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1, 1],[2, 1]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
 
-  out = np.zeros(vcg.shape, dtype=np.uint32, order="F")
-  out[:5,:5,:5] = 1
-  out[5:,:5,:5] = 2
-  out[:5,5:,:5] = 3
-  out[5:,5:,:5] = 4
-  out[:5,:5,5:] = 5
-  out[5:,:5,5:] = 6
-  out[:5,5:,5:] = 7
-  out[5:,5:,5:] = 8
-  
-  assert np.all(out == cc_labels)
+  vcg[:] = 0b1111
+  vcg[0,0] = 0b1010
+  vcg[1,0] = 0b1101
+  vcg[0,1] = 0b0111
+  vcg[1,1] = 0b0111
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1, 3],[2, 3]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1395,7 +1395,7 @@ def test_color_connectivity_graph_26():
   vcg[5,:,:] = vcg[5,:,:] & 0b111101
 
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=26)
-  
+
   out = np.zeros(vcg.shape, dtype=np.uint32, order="F")
   out[:5,:5,:5] = 1
   out[5:,:5,:5] = 2
@@ -1407,4 +1407,20 @@ def test_color_connectivity_graph_26():
   out[5:,5:,5:] = 8
 
   assert np.all(out == cc_labels)
+
+  vcg[4,4,4] = 0b11111111111111111111000000
+  vcg[5,4,4] = 0b11111111111111111111000000
+  vcg[4,5,4] = 0b11111111111111111111000000
+  vcg[5,5,4] = 0b11111111111111111111000000
+
+  vcg[4,4,5] = 0b11111111111111111111000000
+  vcg[5,4,5] = 0b11111111111111111111000000
+  vcg[4,5,5] = 0b11111111111111111111000000
+  vcg[5,5,5] = 0b11111111111111111111000000
+
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=26)
+  assert np.all(cc_labels == 1)
+
+
+
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1278,31 +1278,31 @@ def test_color_connectivity_graph_4(dtype, connectivity):
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
   ans = np.array([[1],[2]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
-  print("THIS TEST")
+
   vcg = np.zeros([1,2], dtype=dtype)
   vcg[:] = 0b1100
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
   ans = np.array([1,1], dtype=np.uint32)
   assert np.all(cc_labels == ans)
-  print("REACHED HERE")
+
   vcg[:] = 0b0011
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
-  print(cc_labels)
+
   ans = np.array([1,2], dtype=np.uint32)
   assert np.all(cc_labels == ans)
-  print("REACHED HERE2")
+
   vcg = np.zeros([2,2], dtype=dtype)
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
   ans = np.array([[1, 3],[2, 4]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
-  print("REACHED HERE3")
+
   vcg[:] = 0b1111
   vcg[0,0] = 0b1110
   vcg[1,0] = 0b1101
   cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
   ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
-  print("REACHED HERE4")
+
   vcg[:] = 0b1111
   vcg[0,0] = 0b1110
   vcg[1,0] = 0b1101

--- a/automated_test.py
+++ b/automated_test.py
@@ -1373,3 +1373,35 @@ def test_color_connectivity_graph_6():
 
   assert np.all(out == cc_labels)
 
+def test_color_connectivity_graph_26():
+
+  with pytest.raises(ValueError):
+    vcg = np.zeros([2,1,2], dtype=np.uint8, order="F")
+    cc3d.color_connectivity_graph(vcg, connectivity=26)
+
+  vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")
+  vcg[:,:,:] = 0b11111111111111111111111111
+
+  vcg[:,:,4] = vcg[:,:,4] & 0b101111
+  vcg[:,:,5] = vcg[:,:,5] & 0b011111
+
+  vcg[:,4,:] = vcg[:,4,:] & 0b111011
+  vcg[:,5,:] = vcg[:,5,:] & 0b110111
+
+  vcg[4,:,:] = vcg[4,:,:] & 0b111110
+  vcg[5,:,:] = vcg[5,:,:] & 0b111101
+
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=26)
+  
+  out = np.zeros(vcg.shape, dtype=np.uint32, order="F")
+  out[:5,:5,:5] = 1
+  out[5:,:5,:5] = 2
+  out[:5,5:,:5] = 3
+  out[5:,5:,:5] = 4
+  out[:5,:5,5:] = 5
+  out[5:,:5,5:] = 6
+  out[:5,5:,5:] = 7
+  out[5:,5:,5:] = 8
+
+  assert np.all(out == cc_labels)
+

--- a/automated_test.py
+++ b/automated_test.py
@@ -1382,6 +1382,9 @@ def test_color_connectivity_graph_26():
   vcg = np.zeros([10,10,10], dtype=np.uint32, order="F")
   vcg[:,:,:] = 0b11111111111111111111111111
 
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=26)
+  assert np.all(cc_labels == 1)
+
   vcg[:,:,4] = vcg[:,:,4] & 0b101111
   vcg[:,:,5] = vcg[:,:,5] & 0b011111
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1330,3 +1330,12 @@ def test_color_connectivity_graph_8_uint8():
   ans = np.array([[1, 2],[2, 1]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
 
+def test_color_connectivity_graph_8_uint32():
+  vcg = np.zeros([2,2], dtype=np.uint32)
+  vcg[0,0] = 0b1000000
+  vcg[1,1] = 0b1000000000
+  vcg[1,0] = 0b10000000
+  vcg[0,1] = 0b100000000
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=8)
+  ans = np.array([[1, 2],[2, 1]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)

--- a/automated_test.py
+++ b/automated_test.py
@@ -1296,14 +1296,12 @@ def test_color_connectivity_graph_4(dtype, connectivity):
   ans = np.array([[1, 3],[2, 4]], dtype=np.uint32)
   assert np.all(cc_labels == ans)
 
-
-  # This is aphysical
-  # vcg[:] = 0b1111
-  # vcg[0,0] = 0b1110
-  # vcg[1,0] = 0b1101
-  # cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
-  # ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
-  # assert np.all(cc_labels == ans)
+  vcg[:] = 0b1111
+  vcg[0,0] = 0b1110
+  vcg[1,0] = 0b1101
+  cc_labels = cc3d.color_connectivity_graph(vcg, connectivity=connectivity)
+  ans = np.array([[1, 1],[1, 1]], dtype=np.uint32)
+  assert np.all(cc_labels == ans)
 
   vcg[:] = 0b1111
   vcg[0,0] = 0b1110

--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -1083,7 +1083,7 @@ OUT* connected_components2d_8(
       else {
         next_label++;
         out_labels[loc] = next_label;
-        equivalences.add(out_labels[loc]);        
+        equivalences.add(out_labels[loc]);      
       }
     }
   }

--- a/cc3d.hpp
+++ b/cc3d.hpp
@@ -137,7 +137,8 @@ public:
   }
 
   void print() {
-    for (int i = 0; i < 15; i++) {
+    int size = std::min(static_cast<int>(length), 15);
+    for (int i = 0; i < size; i++) {
       printf("%d, ", ids[i]);
     }
     printf("\n");

--- a/cc3d.pyx
+++ b/cc3d.pyx
@@ -829,6 +829,9 @@ def color_connectivity_graph(
   cdef int sy = shape[1]
   cdef int sz = shape[2]
 
+  if connectivity in [6,8] and sz > 1 and dtype != np.uint32:
+    raise ValueError(f"Only uint32 is supported for 3d connectivites. Got: {vcg.dtype}")
+
   cdef uint8_t[:,:,:] arr_memview8u
   cdef uint32_t[:,:,:] arr_memview32u
   cdef uint32_t[:,:,:] out_labels32

--- a/cc3d.pyx
+++ b/cc3d.pyx
@@ -815,6 +815,12 @@ def color_connectivity_graph(
   if dtype not in [np.uint8, np.uint32]:
     raise ValueError(f"Only uint8 and uint32 are supported. Got: {vcg.dtype}")
 
+  if vcg.size == 0:
+    return np.zeros([0] * dims, dtype=np.uint32, order="F")
+
+  while vcg.ndim < 3:
+    vcg = vcg[..., np.newaxis]
+
   vcg = np.asfortranarray(vcg)
 
   shape = vcg.shape
@@ -828,8 +834,7 @@ def color_connectivity_graph(
   cdef uint32_t[:,:,:] out_labels32
 
   cdef int64_t voxels = <int64_t>sx * <int64_t>sy * <int64_t>sz
-  cdef cnp.ndarray[uint32_t, ndim=3] out_labels = np.zeros( (sx,sy,sz,), dtype=np.uint32, order='F' )
-  
+  out_labels = np.zeros( (sx,sy,sz,), dtype=np.uint32, order='F' )
   out_labels32 = out_labels
 
   cdef size_t N = 0
@@ -852,6 +857,9 @@ def color_connectivity_graph(
       &out_labels32[0,0,0],
       N
     )
+
+  while out_labels.ndim > dims:
+    out_labels = out_labels[...,0]
 
   if return_N:
     return (out_labels, N)

--- a/cc3d.pyx
+++ b/cc3d.pyx
@@ -829,7 +829,7 @@ def color_connectivity_graph(
   cdef int sy = shape[1]
   cdef int sz = shape[2]
 
-  if connectivity in [6,8] and sz > 1 and dtype != np.uint32:
+  if connectivity in [6, 26] and sz > 1 and dtype != np.uint32:
     raise ValueError(f"Only uint32 is supported for 3d connectivites. Got: {vcg.dtype}")
 
   cdef uint8_t[:,:,:] arr_memview8u

--- a/cc3d.pyx
+++ b/cc3d.pyx
@@ -791,18 +791,25 @@ def _statistics_helper(
 @cython.binding(True)
 def color_connectivity_graph(
   vcg, 
-  connectivity, 
+  connectivity = 26, 
   return_N = False, 
-):
-  """my docstring"""
+) -> np.ndarray:
+  """
+  Given a voxel connectivity graph following the same bit convention as 
+  cc3d.voxel_connectivity_graph (see docstring), assuming an undirected
+  graph (the format supports directed graphs, but this is not implemented
+  for the sake of efficiency), this function will return a uint32 image
+  that contains connected components labeled according to the boundaries 
+  described in the voxel connectivity graph (vcg).
+  """
   cdef int dims = len(vcg.shape)
   if dims not in (2,3):
     raise DimensionError("Only 2D, and 3D arrays supported. Got: " + str(dims))
 
-  if dims == 2 and connectivity not in [4]:
-    raise ValueError(f"Only 4 connectivity is supported for 2D images. Got: {connectivity}")
-  elif dims != 2 and connectivity not in [6]:
-    raise ValueError(f"Only 6 connectivity are supported for 3D images. Got: {connectivity}")
+  if dims == 2 and connectivity not in [4,8,6,26]:
+    raise ValueError(f"Only 4 and 8 connectivity is supported for 2D images. Got: {connectivity}")
+  elif dims != 2 and connectivity not in [6,26]:
+    raise ValueError(f"Only 6 and 26 connectivity are supported for 3D images. Got: {connectivity}")
 
   dtype = vcg.dtype
   if dtype not in [np.uint8, np.uint32]:

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -212,7 +212,7 @@ OUT* extract_voxel_connectivity_graph(
 		graph = extract_voxel_connectivity_graph_3d<T, OUT>(
 			in_labels, sx, sy, sz, graph
 		);
-	 return and_mask<OUT>(0b00111111, graph, sx, sy, sz);
+		return and_mask<OUT>(0b00111111, graph, sx, sy, sz);
 	}
 	else if (connectivity == 8) {
 		if (sz != 1) {

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -633,6 +633,8 @@ OUT* color_connectivity_graph_6(
 			out_labels[x + sxy * z] = new_label;
 		}
 
+		new_label++;
+
 		for (int64_t y = 1; y < sy; y++) {
 			for (int64_t x = 0; x < sx; x++) {
 				int64_t loc = x + sx * y + sxy * z;
@@ -701,6 +703,8 @@ OUT* color_connectivity_graph_8(
 		out_labels[x] = new_label;
 	}
 
+	new_label++;
+
 	/*
 	Layout of mask. We start from e.
 	a | b | c
@@ -720,8 +724,9 @@ OUT* color_connectivity_graph_8(
 		for (int64_t x = 0; x < sx; x++) {
 			int64_t loc = x + sx * y;
 
-			out_labels[loc] = new_label++;
+			out_labels[loc] = new_label;
 			equivalences.add(new_label);
+			new_label++;
 
 			if (vcg[loc] & B_mask) {
 				equivalences.unify(out_labels[loc], out_labels[loc+B]);
@@ -772,6 +777,8 @@ OUT* color_connectivity_graph_8(
 		out_labels[x] = new_label;
 	}
 
+	new_label++;
+
 	/*
 	Layout of mask. We start from e.
 	a | b | c
@@ -791,8 +798,9 @@ OUT* color_connectivity_graph_8(
 		for (int64_t x = 0; x < sx; x++) {
 			int64_t loc = x + sx * y;
 
-			out_labels[loc] = new_label++;
+			out_labels[loc] = new_label;
 			equivalences.add(new_label);
+			new_label++;
 
 			if (vcg[loc] & B_mask) {
 				equivalences.unify(out_labels[loc], out_labels[loc+B]);

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -451,6 +451,22 @@ OUT* color_connectivity_graph_26(
 	throw new std::runtime_error("26-connectivity requires a 32-bit voxel graph for color_connectivity_graph_26.");
 }
 
+template <typename T>
+uint64_t estimate_vcg_provisional_label_count(
+  T* vcg, const int64_t sx, const int64_t voxels
+) {
+  uint64_t count = 0; // number of transitions between labels
+
+  for (int64_t row = 0, loc = 0; loc < voxels; loc += sx, row++) {
+    count++;
+    for (int64_t x = 1; x < sx; x++) {
+      count += static_cast<uint64_t>((vcg[loc + x] & 0b10) == 0);
+    }
+  }
+
+  return count;
+}
+
 template <typename OUT>
 OUT* color_connectivity_graph_26(
 	const uint32_t* vcg, // voxel connectivity graph
@@ -463,6 +479,7 @@ OUT* color_connectivity_graph_26(
 
 	uint64_t max_labels = static_cast<uint64_t>(voxels) + 1; // + 1L for an array with no zeros
 	max_labels = std::min(max_labels, static_cast<uint64_t>(std::numeric_limits<OUT>::max()));
+	max_labels = std::min(max_labels, estimate_vcg_provisional_label_count(vcg, sx, voxels) + 1);
 
 	if (out_labels == NULL) {
 		out_labels = new OUT[voxels]();

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -676,7 +676,7 @@ OUT* color_connectivity_graph_6(
 // need to write this two ways
 template <typename OUT>
 OUT* color_connectivity_graph_8(
-  const uint32_t* vcg, // voxel connectivity graph
+  const uint8_t* vcg, // voxel connectivity graph
   const int64_t sx, const int64_t sy,
   OUT* out_labels = NULL,
   size_t &N = _dummy_N
@@ -750,7 +750,7 @@ OUT* color_connectivity_graph_8(
 // need to write this two ways
 template <typename OUT>
 OUT* color_connectivity_graph_8(
-  const uint8_t* vcg, // voxel connectivity graph
+  const uint32_t* vcg, // voxel connectivity graph
   const int64_t sx, const int64_t sy,
   OUT* out_labels = NULL,
   size_t &N = _dummy_N

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -435,7 +435,7 @@ OUT* simplified_relabel(
   // Raster Scan 2: Write final labels based on equivalences
   N = next_label - 1;
   for (int64_t loc = 0; loc < voxels; loc++) {
-    out_labels[loc] = renumber[out_labels[loc]] - 1; // first label is 0 not 1
+    out_labels[loc] = renumber[out_labels[loc]];
   }
 
   return out_labels;
@@ -527,7 +527,7 @@ OUT* color_connectivity_graph_26(
 
 		for (int64_t y = 1; y < sy; y++) {
 			for (int64_t x = 0; x < sx; x++) {
-				int64_t loc = x + sx * y;
+				int64_t loc = x + sx * y + sxy * z;
 
 				out_labels[loc] = new_label++;
 				equivalences.add(new_label);

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -513,6 +513,7 @@ OUT* color_connectivity_graph_26(
 	// N = 0;
 
 	OUT new_label = 0;
+
 	for (int64_t z = 0; z < sz; z++) {
 		new_label++;
 		equivalences.add(new_label);
@@ -529,21 +530,28 @@ OUT* color_connectivity_graph_26(
 			for (int64_t x = 0; x < sx; x++) {
 				int64_t loc = x + sx * y + sxy * z;
 
-				new_label++;
-				out_labels[loc] = new_label;
-				equivalences.add(new_label);
-
 				if (vcg[loc] & K_mask) {
-					equivalences.unify(out_labels[loc], out_labels[loc+K]);
+					out_labels[loc] = out_labels[loc+K];
 				}
-				if (x > 0 && (vcg[loc] & J_mask)) {
-					equivalences.unify(out_labels[loc], out_labels[loc+J]);
+				else if (x > 0 && (vcg[loc] & J_mask)) {
+					out_labels[loc] = out_labels[loc+J];
+					if (x < sx - 1 && (vcg[loc] & L_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+L]);
+					}
 				}
-				if (x > 0 && (vcg[loc] & M_mask)) {
-					equivalences.unify(out_labels[loc], out_labels[loc+M]);
+				else if (x > 0 && (vcg[loc] & M_mask)) {
+					out_labels[loc] = out_labels[loc+M];
+					if (x < sx - 1 && (vcg[loc] & L_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+L]);
+					}
 				}
-				if (x < sx - 1 && (vcg[loc] & L_mask)) {
-					equivalences.unify(out_labels[loc], out_labels[loc+L]);
+				else if (x < sx - 1 && (vcg[loc] & L_mask)) {
+					out_labels[loc] = out_labels[loc+L];
+				}
+				else {
+					new_label++;
+					out_labels[loc] = new_label;
+					equivalences.add(out_labels[loc]);
 				}
 			}
 		}

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -874,19 +874,21 @@ OUT* color_connectivity_graph_4(
 	}
 
 	const int64_t B = -1;
+	const int64_t B_mask = 0b0010;
 	const int64_t C = -sx;
+	const int64_t C_mask = 0b1000;
 
 	for (int64_t y = 1; y < sy; y++) {
 		for (int64_t x = 0; x < sx; x++) {
 			int64_t loc = x + sx * y;
 
-			if (x > 0 && (vcg[loc] & 0b0010)) {
+			if (x > 0 && (vcg[loc] & B_mask)) {
 				out_labels[loc] = out_labels[loc+B];
-				if (y > 0 && (vcg[loc + C] & 0b0010) == 0 && (vcg[loc] & 0b1000)) {
+				if (vcg[loc] & C_mask) {
 					equivalences.unify(out_labels[loc], out_labels[loc+C]);
 				}
 			}
-			else if (y > 0 && vcg[loc] & 0b1000) {
+			else if (vcg[loc] & C_mask) {
 				out_labels[loc] = out_labels[loc+C];
 			}
 			else {

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -792,12 +792,21 @@ OUT* color_connectivity_graph_N(
   OUT* out_labels = NULL,
   size_t &N = _dummy_N
 ) {
-	if (connectivity != 6 && connectivity != 4) {
-		throw std::runtime_error("Only 4 and 6 connectivities are supported.");
+	if (connectivity != 6 && connectivity != 4 && connectivity != 8) {
+		throw std::runtime_error("Only 4, 8, and 6 connectivities are supported.");
+	}
+
+	if (sz > 1 && connectivity != 6) {
+		throw std::runtime_error("Only 6 connectivity is supported in 3D.");
 	}
 
 	if (sz == 1) {
-		return color_connectivity_graph_4<VCG_t, OUT>(vcg, sx, sy, out_labels, N);
+		if (connectivity == 6 || connectivity == 4) {
+			return color_connectivity_graph_4<VCG_t, OUT>(vcg, sx, sy, out_labels, N);
+		}
+		else {
+			return color_connectivity_graph_8(vcg, sx, sy, out_labels, N);
+		}
 	}
 	else {
 		return color_connectivity_graph_6<VCG_t, OUT>(vcg, sx, sy, sz, out_labels, N);

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -554,23 +554,23 @@ OUT* color_connectivity_graph_26(
 			for (int64_t x = 0; x < sx; x++) {  
 				int64_t loc = x + sx * y + sxy * z;
 
-				if (vcg[loc] & E_mask) {
-					equivalences.unify(out_labels[loc], out_labels[loc+E]);
-				}
-				if (x > 0 && (vcg[loc] & D_mask)) {
-					equivalences.unify(out_labels[loc], out_labels[loc+D]);
-				}
-				if (x < sx - 1 && (vcg[loc] & F_mask)) {
-					equivalences.unify(out_labels[loc], out_labels[loc+F]);
-				}
 				if (x > 0 && y > 0 && (vcg[loc] & A_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+A]);
 				}
 				if (y > 0 && (vcg[loc] & B_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+B]);
 				}
-				if (x > 0 && y < sy - 1 && (vcg[loc] & C_mask)) {
+				if (x < sx - 1 && y < sy - 1 && (vcg[loc] & C_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+C]);
+				}
+				if (x > 0 && (vcg[loc] & D_mask)) {
+					equivalences.unify(out_labels[loc], out_labels[loc+D]);
+				}
+				if (vcg[loc] & E_mask) {
+					equivalences.unify(out_labels[loc], out_labels[loc+E]);
+				}
+				if (x < sx - 1 && (vcg[loc] & F_mask)) {
+					equivalences.unify(out_labels[loc], out_labels[loc+F]);
 				}
 				if (x > 0 && y < sy - 1 && (vcg[loc] & G_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+G]);

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -727,8 +727,6 @@ OUT* color_connectivity_graph_8(
 		out_labels[x] = new_label;
 	}
 
-	new_label++;
-
 	/*
 	Layout of mask. We start from e.
 	a | b | c
@@ -748,22 +746,29 @@ OUT* color_connectivity_graph_8(
 		for (int64_t x = 0; x < sx; x++) {
 			int64_t loc = x + sx * y;
 
-			out_labels[loc] = new_label;
-			equivalences.add(new_label);
-			new_label++;
-
-			if (vcg[loc] & B_mask) {
-				equivalences.unify(out_labels[loc], out_labels[loc+B]);
-			}
-			if (x > 0 && (vcg[loc] & A_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+A]);
-			}
-			if (x > 0 && (vcg[loc] & D_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+D]);
-			}
-			if (x < sx - 1 && (vcg[loc] & C_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+C]);
-			}
+				if (vcg[loc] & B_mask) {
+					out_labels[loc] = out_labels[loc+B];
+				}
+				else if (x > 0 && (vcg[loc] & A_mask)) {
+					out_labels[loc] = out_labels[loc+A];
+					if (x < sx - 1 && (vcg[loc] & C_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+C]);
+					}
+				}
+				else if (x > 0 && (vcg[loc] & D_mask)) {
+					out_labels[loc] = out_labels[loc+D];
+					if (x < sx - 1 && (vcg[loc] & C_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+C]);
+					}
+				}
+				else if (x < sx - 1 && (vcg[loc] & C_mask)) {
+					out_labels[loc] = out_labels[loc+C];
+				}
+				else {
+					new_label++;
+					out_labels[loc] = new_label;
+					equivalences.add(out_labels[loc]);
+				}
 		}
 	}
 
@@ -801,8 +806,6 @@ OUT* color_connectivity_graph_8(
 		out_labels[x] = new_label;
 	}
 
-	new_label++;
-
 	/*
 	Layout of mask. We start from e.
 	a | b | c
@@ -822,22 +825,29 @@ OUT* color_connectivity_graph_8(
 		for (int64_t x = 0; x < sx; x++) {
 			int64_t loc = x + sx * y;
 
-			out_labels[loc] = new_label;
-			equivalences.add(new_label);
-			new_label++;
-
-			if (vcg[loc] & B_mask) {
-				equivalences.unify(out_labels[loc], out_labels[loc+B]);
-			}
-			if (x > 0 && (vcg[loc] & A_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+A]);
-			}
-			if (x > 0 && (vcg[loc] & D_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+D]);
-			}
-			if (x < sx - 1 && (vcg[loc] & C_mask)) {
-				equivalences.unify(out_labels[loc], out_labels[loc+C]);
-			}
+				if (vcg[loc] & B_mask) {
+					out_labels[loc] = out_labels[loc+B];
+				}
+				else if (x > 0 && (vcg[loc] & A_mask)) {
+					out_labels[loc] = out_labels[loc+A];
+					if (x < sx - 1 && (vcg[loc] & C_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+C]);
+					}
+				}
+				else if (x > 0 && (vcg[loc] & D_mask)) {
+					out_labels[loc] = out_labels[loc+D];
+					if (x < sx - 1 && (vcg[loc] & C_mask)) {
+						equivalences.unify(out_labels[loc], out_labels[loc+C]);
+					}
+				}
+				else if (x < sx - 1 && (vcg[loc] & C_mask)) {
+					out_labels[loc] = out_labels[loc+C];
+				}
+				else {
+					new_label++;
+					out_labels[loc] = new_label;
+					equivalences.add(out_labels[loc]);
+				}
 		}
 	}
 

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -529,7 +529,8 @@ OUT* color_connectivity_graph_26(
 			for (int64_t x = 0; x < sx; x++) {
 				int64_t loc = x + sx * y + sxy * z;
 
-				out_labels[loc] = new_label++;
+				new_label++;
+				out_labels[loc] = new_label;
 				equivalences.add(new_label);
 
 				if (vcg[loc] & K_mask) {
@@ -632,8 +633,6 @@ OUT* color_connectivity_graph_6(
 			}
 			out_labels[x + sxy * z] = new_label;
 		}
-
-		new_label++;
 
 		for (int64_t y = 1; y < sy; y++) {
 			for (int64_t x = 0; x < sx; x++) {

--- a/cc3d_graphs.hpp
+++ b/cc3d_graphs.hpp
@@ -568,7 +568,7 @@ OUT* color_connectivity_graph_26(
 				if (y > 0 && (vcg[loc] & B_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+B]);
 				}
-				if (x < sx - 1 && y < sy - 1 && (vcg[loc] & C_mask)) {
+				if (x < sx - 1 && y > 0 && (vcg[loc] & C_mask)) {
 					equivalences.unify(out_labels[loc], out_labels[loc+C]);
 				}
 				if (x > 0 && (vcg[loc] & D_mask)) {


### PR DESCRIPTION
Adds `cc3d.color_connectivity_graph`

This function provides a way to convert uint8 and uint32 voxel connectivity graphs generated by cc3d into labeled images. These connectivity graphs are useful for representing "self-touch" labels.

Supports 4,8,6, and 26 connectivity.