### PR TITLE
perf: apply spaghetti inspired procedure to 4-connected

### DIFF
--- a/cc3d/cc3d.hpp
+++ b/cc3d/cc3d.hpp
@@ -1079,7 +1079,7 @@ OUT* connected_components3d_6(
 // As of June 2026, this is currently the most cutting edge single-threaded
 // CPU algorithm available. Only 4 and 6 are really tractable to write by hand.
 // One difference in this implementation from Bolelli's implementation in opencv
-// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his tree_0 and tree_1).
+// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his cl_tree_1 and cl_tree_0).
 // It's not clear if this is better or even.
 // I wrote this based on the spaghetti idea then looked at OpenCV. It's remarkable
 // how the structure is nearly identical after optimization. Bollelli is the champ.

--- a/cc3d/cc3d_binary.hpp
+++ b/cc3d/cc3d_binary.hpp
@@ -579,12 +579,6 @@ OUT* connected_components3d_6_binary(
 // Uses the "Spaghetti labeling" algorithm for 4-connected.
 // As of June 2026, this is currently the most cutting edge single-threaded
 // CPU algorithm available. Only 4 and 6 are really tractable to write by hand.
-// One difference in this implementation from Bolelli's implementation in opencv
-// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his cl_tree_1 and cl_tree_0).
-// It's not clear if this is better or even. Another difference is the explict check of D
-// to avoid the union find.
-// I wrote this based on the spaghetti idea then looked at OpenCV. It's remarkable
-// how the structure is nearly identical after optimization. Bollelli is the champ.
 
 // One possible direction for further improvement: 
 // The spaghetti decision tree maximally avoids unify calls, but a significant amount
@@ -690,6 +684,11 @@ OUT* connected_components2d_4_binary(
       equivalences.add(out_labels[loc]);
       goto COMPLEX;
     }
+
+    // After the first pixel, you are either
+    // coming from a foreground or a background pixel.
+    // Only the pixel following a background pixel can
+    // possibly create a new label.
 
     COMPLEX:
       x++;

--- a/cc3d/cc3d_binary.hpp
+++ b/cc3d/cc3d_binary.hpp
@@ -576,10 +576,24 @@ OUT* connected_components3d_6_binary(
 }
 
 
-// uses an approach inspired by 2x2 block based decision trees
-// by Grana et al that was intended for 8-connected. Here we 
-// skip a unify on every other voxel in the horizontal and
-// vertical directions.
+// Uses the "Spaghetti labeling" algorithm for 4-connected.
+// As of June 2026, this is currently the most cutting edge single-threaded
+// CPU algorithm available. Only 4 and 6 are really tractable to write by hand.
+// One difference in this implementation from Bolelli's implementation in opencv
+// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his tree_0 and tree_1).
+// It's not clear if this is better or even.
+// I wrote this based on the spaghetti idea then looked at OpenCV. It's remarkable
+// how the structure is nearly identical after optimization. Bollelli is the champ.
+
+// One possible direction for further improvement: 
+// The spaghetti decision tree maximally avoids unify calls, but a significant amount
+// of time is spent writing labels in the first pass. If that could be avoided without
+// wasting time elsewhere, that could speed things up.
+
+// F. Bolelli, S. Allegretti, L. Baraldi, and C. Grana, 
+// "Spaghetti Labeling: Directed Acyclic Graphs for Block-Based Connected Components Labeling," 
+// IEEE Transactions on Image Processing, vol. 29, pp. 1999–2012, 2020, 
+// doi: 10.1109/TIP.2019.2946979.
 template <typename T, typename OUT = uint32_t>
 OUT* connected_components2d_4_binary(
     T* in_labels, 

--- a/cc3d/cc3d_binary.hpp
+++ b/cc3d/cc3d_binary.hpp
@@ -580,8 +580,9 @@ OUT* connected_components3d_6_binary(
 // As of June 2026, this is currently the most cutting edge single-threaded
 // CPU algorithm available. Only 4 and 6 are really tractable to write by hand.
 // One difference in this implementation from Bolelli's implementation in opencv
-// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his tree_0 and tree_1).
-// It's not clear if this is better or even.
+// is the use of the BLACK tree (COMPLEX and SIMPLE correspond to his cl_tree_1 and cl_tree_0).
+// It's not clear if this is better or even. Another difference is the explict check of D
+// to avoid the union find.
 // I wrote this based on the spaghetti idea then looked at OpenCV. It's remarkable
 // how the structure is nearly identical after optimization. Bollelli is the champ.
 
@@ -671,8 +672,10 @@ OUT* connected_components2d_4_binary(
     }
     else if (x > 0 && in_labels[loc + B]) {
       out_labels[loc] = out_labels[loc + B];
-      if (in_labels[loc + C] && !in_labels[loc + D]) {
-        equivalences.unify(out_labels[loc], out_labels[loc + C]);
+      if (in_labels[loc + C]) {
+        if (!in_labels[loc + D]) {
+          equivalences.unify(out_labels[loc], out_labels[loc + C]);
+        }
         goto SIMPLE;
       }
       goto COMPLEX;
@@ -698,24 +701,14 @@ OUT* connected_components2d_4_binary(
       if (in_labels[loc] == 0) {
         goto BLACK;
       }
-      else if (in_labels[loc + B]) {
-        out_labels[loc] = out_labels[loc + B];
-        if (in_labels[loc + C] && !in_labels[loc + D]) {
-          equivalences.unify(out_labels[loc], out_labels[loc + C]);
-          goto SIMPLE;
-        }
-        goto COMPLEX;
-      }
-      else if (in_labels[loc + C]) {
-        out_labels[loc] = out_labels[loc + C];
+      
+      out_labels[loc] = out_labels[loc + B];
+
+      if (in_labels[loc + C]) {
+        equivalences.unify(out_labels[loc], out_labels[loc + C]);
         goto SIMPLE;
       }
-      else {
-        next_label++;
-        out_labels[loc] = next_label;
-        equivalences.add(out_labels[loc]);
-        goto COMPLEX;
-      }
+      goto COMPLEX;
 
     SIMPLE:
       x++;
@@ -731,14 +724,8 @@ OUT* connected_components2d_4_binary(
         out_labels[loc] = out_labels[loc + C];
         goto SIMPLE;
       }
-      else if (in_labels[loc + B]) {
-        out_labels[loc] = out_labels[loc + B];
-        goto COMPLEX;
-      }
       else {
-        next_label++;
-        out_labels[loc] = next_label;
-        equivalences.add(out_labels[loc]);
+        out_labels[loc] = out_labels[loc + B];
         goto COMPLEX;
       }
 

--- a/cc3d/cc3d_binary.hpp
+++ b/cc3d/cc3d_binary.hpp
@@ -576,9 +576,8 @@ OUT* connected_components3d_6_binary(
 }
 
 
-// Uses the "Spaghetti labeling" algorithm for 4-connected.
-// As of June 2026, this is currently the most cutting edge single-threaded
-// CPU algorithm available. Only 4 and 6 are really tractable to write by hand.
+// Uses a "Spaghetti labeling" inspired algorithm for 4-connected.
+// Only 4 and 6 connected are really tractable to write by hand.
 
 // One possible direction for further improvement: 
 // The spaghetti decision tree maximally avoids unify calls, but a significant amount

--- a/cc3d/cc3d_binary.hpp
+++ b/cc3d/cc3d_binary.hpp
@@ -628,31 +628,126 @@ OUT* connected_components2d_4_binary(
   // Raster Scan 1: Set temporary labels and 
   // record equivalences in a disjoint set.
 
-  for (int64_t y = 0; y < sy; y++, row++) {
-    const int64_t xstart = runs[row << 1];
-    const int64_t xend = runs[(row << 1) + 1];
+  int64_t xstart = runs[0];
+  int64_t xend = runs[1];
+  loc = xstart;
 
-    for (int64_t x = xstart; x < xend; x++) {
-      loc = x + sx * y;
+  for (int64_t x = xstart; x < xend; x++, loc++) {
+    if (in_labels[loc] == 0) {
+      continue;
+    }
+    else if (x > 0 && in_labels[loc] == in_labels[loc + B]) {
+      out_labels[loc] = out_labels[loc + B];
+    }
+    else {
+      next_label++;
+      out_labels[loc] = next_label;
+      equivalences.add(out_labels[loc]);
+    }
+  }
 
-      if (in_labels[loc] == 0) {
+  for (int64_t y = 1; y < sy; y++) {
+    xstart = runs[y << 1];
+    xend = runs[(y << 1) + 1];
+    loc = xstart + sx * y;
+    int64_t x = xstart;
+
+    if (in_labels[loc] == 0) {
+      goto BLACK;
+    }
+    else if (x > 0 && in_labels[loc + B]) {
+      out_labels[loc] = out_labels[loc + B];
+      if (in_labels[loc + C] && !in_labels[loc + D]) {
+        equivalences.unify(out_labels[loc], out_labels[loc + C]);
+        goto SIMPLE;
+      }
+      goto COMPLEX;
+    }
+    else if (in_labels[loc + C]) {
+      out_labels[loc] = out_labels[loc + C];
+      goto SIMPLE;
+    }
+    else {
+      next_label++;
+      out_labels[loc] = next_label;
+      equivalences.add(out_labels[loc]);
+      goto COMPLEX;
+    }
+
+    COMPLEX:
+      x++;
+      loc++;
+      if (x >= xend) {
         continue;
       }
-      else if (x > 0 && in_labels[loc + B]) {
-        out_labels[loc + A] = out_labels[loc + B];
-        if (y > 0 && !in_labels[loc + D] && in_labels[loc + C]) {
-          equivalences.unify(out_labels[loc + A], out_labels[loc + C]);
-        }
+
+      if (in_labels[loc] == 0) {
+        goto BLACK;
       }
-      else if (y > 0 && in_labels[loc + C]) {
-        out_labels[loc + A] = out_labels[loc + C];
+      else if (in_labels[loc + B]) {
+        out_labels[loc] = out_labels[loc + B];
+        if (in_labels[loc + C] && !in_labels[loc + D]) {
+          equivalences.unify(out_labels[loc], out_labels[loc + C]);
+          goto SIMPLE;
+        }
+        goto COMPLEX;
+      }
+      else if (in_labels[loc + C]) {
+        out_labels[loc] = out_labels[loc + C];
+        goto SIMPLE;
       }
       else {
         next_label++;
-        out_labels[loc + A] = next_label;
-        equivalences.add(out_labels[loc + A]);
+        out_labels[loc] = next_label;
+        equivalences.add(out_labels[loc]);
+        goto COMPLEX;
       }
-    }
+
+    SIMPLE:
+      x++;
+      loc++;
+      if (x >= xend) {
+        continue;
+      }
+
+      if (in_labels[loc] == 0) {
+        goto BLACK;
+      }
+      else if (in_labels[loc + C]) {
+        out_labels[loc] = out_labels[loc + C];
+        goto SIMPLE;
+      }
+      else if (in_labels[loc + B]) {
+        out_labels[loc] = out_labels[loc + B];
+        goto COMPLEX;
+      }
+      else {
+        next_label++;
+        out_labels[loc] = next_label;
+        equivalences.add(out_labels[loc]);
+        goto COMPLEX;
+      }
+
+    BLACK:
+      x++;
+      loc++;
+      if (x >= xend) {
+        continue;
+      }
+
+      if (in_labels[loc] == 0) {
+        goto BLACK;
+      }
+      else if (in_labels[loc + C]) {
+        out_labels[loc] = out_labels[loc + C];
+        goto SIMPLE;
+      }
+      else {
+        next_label++;
+        out_labels[loc] = next_label;
+        equivalences.add(out_labels[loc]);
+        goto COMPLEX;
+      }
   }
 
   if (periodic_boundary) {

--- a/cc3d/fastcc3d.pyx
+++ b/cc3d/fastcc3d.pyx
@@ -364,14 +364,24 @@ def connected_components(
   cdef cnp.ndarray[uint32_t, ndim=1] out_labels32 = np.array([], dtype=np.uint32)
   cdef cnp.ndarray[uint64_t, ndim=1] out_labels64 = np.array([], dtype=np.uint64)
 
-  epl, first_foreground_row, last_foreground_row = estimate_provisional_labels(data)
+  dtype = data.dtype
+  binary_image = binary_image or (dtype == bool)
+
+  # EPL saves time for multilabel because it helps us reduce the size of 
+  # the union-find allocation. However, for 2D binary images, we can use
+  # a static calculation to save 1/2 to 1/8 of the allocation. We unfortunately
+  # lose hyperfast calculation of extremely sparse images (e.g. 1 pixel or line of pixels)
+  # but reducing passes on the image improves times significantly for typical images.
+  if binary_image and connectivity in (4,8):
+    epl = voxels
+    first_foreground_row = 0
+    last_foreground_row = sy
+  else:
+    epl, first_foreground_row, last_foreground_row = estimate_provisional_labels(data)
 
   if max_labels <= 0:
     max_labels = voxels
   max_labels = min(max_labels, epl, voxels)
-
-  dtype = data.dtype
-  binary_image = binary_image or (dtype == bool)
 
   if np.issubdtype(dtype, np.floating):
     delta = float(delta)


### PR DESCRIPTION
Handles label transitions between foreground and background.

Drops EPL estimation for binary 2d images as the extra pass doesn't buy enough when you can use a static analysis to drop the allocation size. Though maybe it would make sense to keep it for memory constrained applications. On the other hand, for memory constrained applications, we should really be using a dillencourt type algorithm.